### PR TITLE
Don't stop on 'anaconda upload' errors; add 'conda build purge'

### DIFF
--- a/pkgbld/release.py
+++ b/pkgbld/release.py
@@ -59,8 +59,10 @@ def release(repo_name, pkg_name, version):
 
     Notes
     -----
-    Example usage: release('Tax-Calculator', 'taxcalc', '0.23.0')
+    Example usage: release('Tax-Calculator', 'taxcalc', '0.22.2')
     """
+    # pylint: disable=too-many-statements
+
     # check parameters
     if not isinstance(repo_name, str):
         raise ValueError('repo_name is not a string object')
@@ -81,12 +83,12 @@ def release(repo_name, pkg_name, version):
         token = tfile.read()
 
     # show release details
-    print(': Package-Builder building packages for:')
+    print(': Package-Builder will build model packages for:')
     print(':   repository_name = {}'.format(repo_name))
     print(':   package_name = {}'.format(pkg_name))
     print(':   model_version = {}'.format(version))
     print(':   python_versions = {}'.format(PYTHON_VERSIONS))
-    print(': Package-Builder uploading packages to:')
+    print(': Package-Builder will upload model packages to:')
     print(':   Anaconda channel = {}'.format(ANACONDA_CHANNEL))
 
     # make empty working directory
@@ -96,6 +98,7 @@ def release(repo_name, pkg_name, version):
     os.chdir(WORKING_DIR)
 
     # clone model repository and checkout model version
+    print(': ... cloning repository')
     cmd = 'git clone {}/{}/'.format(GITHUB_URL, repo_name)
     u.os_call(cmd)
     os.chdir(repo_name)
@@ -103,18 +106,21 @@ def release(repo_name, pkg_name, version):
     u.os_call(cmd)
 
     # specify version in repository's conda.recipe/meta.yaml file
+    print(': ... setting version')
     u.specify_version(version)
 
     # build and upload model package for each Python version and OS platform
     local_platform = u.conda_platform_name()
     for pyver in PYTHON_VERSIONS:
         # ... build for local_platform
+        print(': ... building package for Python {}'.format(pyver))
         cmd = ('conda build --python {} --old-build-string '
                '--channel {} --override-channels '
                '--no-anaconda-upload --output-folder {} '
                'conda.recipe').format(pyver, ANACONDA_CHANNEL, BUILDS_DIR)
         u.os_call(cmd)
         # ... convert local build to other OS_PLATFORMS
+        print(': ... converting package for Python {}'.format(pyver))
         pyver_parts = pyver.split('.')
         pystr = pyver_parts[0] + pyver_parts[1]
         pkgfile = '{}-{}-py{}_0.tar.bz2'.format(pkg_name, version, pystr)
@@ -123,16 +129,33 @@ def release(repo_name, pkg_name, version):
             if platform == local_platform:
                 continue
             cmd = 'conda convert -p {} -o {} {}'.format(
-                platform, BUILDS_DIR, pkgpath)
+                platform, BUILDS_DIR, pkgpath
+            )
             u.os_call(cmd)
         # ... upload to Anaconda Cloud
+        print(': ... uploading packages for Python {}'.format(pyver))
         for platform in OS_PLATFORMS:
             pkgpath = os.path.join(BUILDS_DIR, platform, pkgfile)
             cmd = 'anaconda --token {} upload --user {} {}'.format(
                 token, ANACONDA_USER, pkgpath
             )
-            u.os_call(cmd)
+            try:
+                u.os_call(cmd)
+            except OSError:
+                msg = (': ... Package-Builder WARNING: anaconda upload '
+                       'FAILED for {}/{} perhaps because package already '
+                       'exists in the Anaconda Cloud ... '
+                       'continuing').format(platform, pkgfile)
+                print(msg)
+         
+    print(': ... cleaning-up')
 
     # remove working directory and its contents
     os.chdir(HOME_DIR)
     shutil.rmtree(WORKING_DIR)
+
+    # remove local packages made during this process
+    cmd = 'conda build purge'
+    u.os_call(cmd)
+
+    print(': Package-Builder is finished')


### PR DESCRIPTION
This pull request adds a clean-up command (`conda build purge`) and a `try ... except` statement to catch any `OSError` generated by the `anaconda upload` command, which is most likely being generated by the fact that the package that is being uploaded already exists in the Anaconda Cloud.  This approach is taken from the earlier version authored by @jbcrail.