### PR TITLE
Add pbrelease CLI to release function

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -2,6 +2,10 @@ package:
   name: pkgbld
   version: 0.0.0
 
+build:
+  entry_points:
+    - pbrelease = pkgbld.cli:main
+
 requirements:
   build:
     - python=3.6
@@ -16,6 +20,10 @@ requirements:
 test:
   imports:
     - pkgbld
+  commands:
+    - which pbrelease  # [unix]
+    - where pbrelease  # [win]
+    - pbrelease --help
 
 about:
   home: https://github.com/open-source-economics/Package-Builder

--- a/pkgbld/__init__.py
+++ b/pkgbld/__init__.py
@@ -3,6 +3,7 @@ Specify what is available to import from the pkgbld package.
 """
 from pkgbld.utils import *
 from pkgbld.release import *
+from pkgbld.cli import *
 
 from pkgbld._version import get_versions
 __version__ = get_versions()['version']

--- a/pkgbld/cli.py
+++ b/pkgbld/cli.py
@@ -1,0 +1,62 @@
+"""
+Command-line interface (CLI) to Package-Builder response function,
+which can be accessed as 'pbrelease' from an installed pkgbld conda package.
+"""
+# CODING-STYLE CHECKS:
+# pycodestyle cli.py
+# pylint --disable=locally-disabled cli.py
+
+import sys
+import argparse
+import pkgbld
+
+
+def main():
+    """
+    Contains command-line interface (CLI) to Package-Builder response function.
+    """
+    # parse command-line arguments:
+    usage_str = ('pbrelease  REPOSITORY_NAME  PACKAGE_NAME  MODEL_VERSION\n'
+                 '                  [--help]  [--version]')
+    parser = argparse.ArgumentParser(
+        prog='',
+        usage=usage_str,
+        description=('Creates conda packages named PACKAGE_NAME for the PSL '
+                     'model in REPOSITORY_NAME that has a MODEL_VERSION '
+                     'release.  The packages are build locally in a '
+                     'temporary workspace and then uploaded to the '
+                     'Anaconda Cloud PSLmodels channel for public '
+                     'distribution.')
+    )
+    parser.add_argument('REPOSITORY_NAME', nargs='?',
+                        help=('Name of repository in the GitHub organization '
+                              'called pslmodels (nee open-source-economics). '
+                              'Example: Tax-Calculator'),
+                        default=None)
+    parser.add_argument('PACKAGE_NAME', nargs='?',
+                        help=('Name of packages to build and upload. '
+                              'Example: taxcalc'),
+                        default=None)
+    parser.add_argument('MODEL_VERSION', nargs='?',
+                        help=('Model release string that is consistent '
+                              'with semantic-versioning rules. '
+                              'Example: 0.22.2'),
+                        default=None)
+    parser.add_argument('--version',
+                        help=('optional flag that writes Package-Builder '
+                              'release version to stdout and quits'),
+                        default=False,
+                        action="store_true")
+    args = parser.parse_args()
+    # show Package-Builder version and quit if --version option specified
+    if args.version:
+        version = pkgbld.__version__
+        if version == 'unknown':
+            version = 'locally.generated.package'
+        sys.stdout.write('Package-Builder {}\n'.format(version))
+        return 0
+    # call pkgbld release function with specified parameters
+    pkgbld.release(repo_name=args.REPOSITORY_NAME,
+                   pkg_name=args.PACKAGE_NAME,
+                   version=args.MODEL_VERSION)
+    return 0

--- a/pkgbld/release.py
+++ b/pkgbld/release.py
@@ -98,7 +98,7 @@ def release(repo_name, pkg_name, version):
     os.chdir(WORKING_DIR)
 
     # clone model repository and checkout model version
-    print(': ... cloning repository')
+    print(': Package-Builder is cloning repository')
     cmd = 'git clone {}/{}/'.format(GITHUB_URL, repo_name)
     u.os_call(cmd)
     os.chdir(repo_name)
@@ -106,21 +106,23 @@ def release(repo_name, pkg_name, version):
     u.os_call(cmd)
 
     # specify version in repository's conda.recipe/meta.yaml file
-    print(': ... setting version')
+    print(': Package-Builder is setting version')
     u.specify_version(version)
 
     # build and upload model package for each Python version and OS platform
     local_platform = u.conda_platform_name()
     for pyver in PYTHON_VERSIONS:
         # ... build for local_platform
-        print(': ... building package for Python {}'.format(pyver))
+        print((': Package-Builder is building package '
+               'for Python {}').format(pyver))
         cmd = ('conda build --python {} --old-build-string '
                '--channel {} --override-channels '
                '--no-anaconda-upload --output-folder {} '
                'conda.recipe').format(pyver, ANACONDA_CHANNEL, BUILDS_DIR)
         u.os_call(cmd)
         # ... convert local build to other OS_PLATFORMS
-        print(': ... converting package for Python {}'.format(pyver))
+        print((': Package-Builder is converting package '
+               'for Python {}').format(pyver))
         pyver_parts = pyver.split('.')
         pystr = pyver_parts[0] + pyver_parts[1]
         pkgfile = '{}-{}-py{}_0.tar.bz2'.format(pkg_name, version, pystr)
@@ -133,7 +135,8 @@ def release(repo_name, pkg_name, version):
             )
             u.os_call(cmd)
         # ... upload to Anaconda Cloud
-        print(': ... uploading packages for Python {}'.format(pyver))
+        print((': Package-Builder is uploading packages '
+               'for Python {}').format(pyver))
         for platform in OS_PLATFORMS:
             pkgpath = os.path.join(BUILDS_DIR, platform, pkgfile)
             cmd = 'anaconda --token {} upload --user {} {}'.format(
@@ -142,13 +145,13 @@ def release(repo_name, pkg_name, version):
             try:
                 u.os_call(cmd)
             except OSError:
-                msg = (': ... Package-Builder WARNING: anaconda upload '
+                msg = (': Package-Builder WARNING: anaconda upload '
                        'FAILED for {}/{} perhaps because package already '
                        'exists in the Anaconda Cloud ... '
                        'continuing').format(platform, pkgfile)
                 print(msg)
 
-    print(': ... cleaning-up')
+    print(': Package-Builder is cleaning-up')
 
     # remove working directory and its contents
     os.chdir(HOME_DIR)


### PR DESCRIPTION
This pull request adds to the Package-Builder `pkgbld` package a CLI to the release function.  This means that when the `pkgbld` package is installed, it is possible to build and upload to the Anaconda Cloud conda packages for any release of a Policy Simulation Library (PSL) model that follows the PSL conda-building criteria.  This can be accomplished as the operating-system command prompt as in the following example:
```
$ conda install -c PSLmodels pkgbld --yes
$ pbrelease B-Tax btax 0.2.5
```
The second command produces an enormous amount of output to the screen because it invokes several `conda` and `anaconda` utilities that produce enormous amount of output that are a mixture of writes to stdout (1) and writes to stderr (2).  If you're working on a Mac, you can filter out all the output except for what Package-Builder writes by executing this command:
```
$ script -q /dev/null pbrelease B-Tax btax 0.2.5 2>&1 | awk '$1==":"'
: Package-Builder will build model packages for:
:   repository_name = B-Tax
:   package_name = btax
:   model_version = 0.2.5
:   python_versions = ['3.6']
: Package-Builder will upload model packages to:
:   Anaconda channel = pslmodels
: Package-Builder is cloning repository
: Package-Builder is setting version
: Package-Builder is building package for Python 3.6
: Package-Builder is converting package for Python 3.6
: Package-Builder is uploading packages for Python 3.6
: Package-Builder is cleaning-up
: Package-Builder is finished
```

Here is the help for the `pbrelease` CLI:
```
$ pbrelease --help
usage: pbrelease  REPOSITORY_NAME  PACKAGE_NAME  MODEL_VERSION
                  [--help]  [--version]

Creates conda packages named PACKAGE_NAME for the PSL model in REPOSITORY_NAME
that has a MODEL_VERSION release. The packages are build locally in a
temporary workspace and then uploaded to the Anaconda Cloud PSLmodels channel
for public distribution.

positional arguments:
  REPOSITORY_NAME  Name of repository in the GitHub organization called
                   pslmodels (nee open-source-economics). Example: Tax-
                   Calculator
  PACKAGE_NAME     Name of packages to build and upload. Example: taxcalc
  MODEL_VERSION    Model release string that is consistent with semantic-
                   versioning rules. Example: 0.22.2

optional arguments:
  -h, --help       show this help message and exit
  --version        optional flag that writes Package-Builder release version
                   to stdout and quits
```

@MattHJensen @hdoupe @jdebacker @rickecon 

