### PR TITLE
Make 'git clone' faster by downloading only code for version (not the whole repository)

### DIFF
--- a/pkgbld/release.py
+++ b/pkgbld/release.py
@@ -97,9 +97,12 @@ def release(repo_name, pkg_name, version):
     os.mkdir(WORKING_DIR)
     os.chdir(WORKING_DIR)
 
-    # clone model repository and checkout model version
-    print(': Package-Builder is cloning repository')
-    cmd = 'git clone {}/{}/'.format(GITHUB_URL, repo_name)
+    # clone code for model_version from model repository
+    print((': Package-Builder is cloning repository code '
+           ' for {}'.format(version)))
+    cmd = 'git clone --branch {} --depth 1 {}/{}/'.format(
+        version, GITHUB_URL, repo_name
+    )
     u.os_call(cmd)
     os.chdir(repo_name)
     cmd = 'git checkout -b v{ver} {ver}'.format(ver=version)

--- a/pkgbld/release.py
+++ b/pkgbld/release.py
@@ -105,8 +105,6 @@ def release(repo_name, pkg_name, version):
     )
     u.os_call(cmd)
     os.chdir(repo_name)
-    cmd = 'git checkout -b v{ver} {ver}'.format(ver=version)
-    u.os_call(cmd)
 
     # specify version in several repository files
     print(': Package-Builder is setting version')


### PR DESCRIPTION
This pull request implements a significant speed-up in Package-Builder by avoiding the download of the whole repository and then doing a checkout of the specified version.  The speed-up is implemented by using "git clone" options that download only the code for the specified version.  No change in the basic logic of the Package-Builder.